### PR TITLE
fix(view): 修复输入时弹窗会超出屏幕的问题

### DIFF
--- a/Fire/CandidatesWindow.swift
+++ b/Fire/CandidatesWindow.swift
@@ -11,8 +11,14 @@ import InputMethodKit
 
 var set = false
 
-class CandidatesWindow: NSWindow {
+class CandidatesWindow: NSWindow, NSWindowDelegate {
     let hostingView = NSHostingView(rootView: CandidatesView(candidates: [], origin: ""))
+
+    func windowDidResize(_ notification: Notification) {
+        // 窗口大小变化时，确保不会超出当前屏幕范围
+        let origin = self.transformTopLeft(originalTopLeft: NSPoint(x: self.frame.minX, y: self.frame.maxY))
+        self.setFrameTopLeftPoint(origin)
+    }
 
     func setCandidates(
         candidates: [Candidate],
@@ -21,8 +27,7 @@ class CandidatesWindow: NSWindow {
     ) {
         hostingView.rootView.candidates = candidates
         hostingView.rootView.origin = originalString
-        let origin = self.transformTopLeft(originalTopLeft: topLeft)
-        self.setFrameTopLeftPoint(origin)
+        self.setFrameTopLeftPoint(topLeft)
         self.orderFront(nil)
     }
 
@@ -38,6 +43,7 @@ class CandidatesWindow: NSWindow {
         styleMask = .init(arrayLiteral: .fullSizeContentView, .borderless)
         isReleasedWhenClosed = false
         backgroundColor = NSColor.clear
+        delegate = self
         setSizePolicy()
     }
 


### PR DESCRIPTION
原方式设置数据后立刻通过window.frame去拿窗口的大小和位置信息是不正确的，由于此时窗口还没有更新，所以拿到的数据其实是上次布局后的矩形信息。
此次使用NSWindowDelegate的windowDidResize方法，在窗口大小发生变化时，立刻去检测更新窗口的位置，可以保证窗口按预期方式工作