### PR TITLE
fix(view): 修复输入时弹窗会超出屏幕的问题 (#28)

### DIFF
--- a/Fire.xcodeproj/project.pbxproj
+++ b/Fire.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		673C416925468A4800F462A3 /* FireMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673C416825468A4800F462A3 /* FireMenu.swift */; };
 		673C417225468FFA00F462A3 /* ModifierKeyUpChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673C417125468FFA00F462A3 /* ModifierKeyUpChecker.swift */; };
 		673C4178254697E400F462A3 /* TipsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 673C4177254697E400F462A3 /* TipsWindow.swift */; };
+		677A0874254BD47D000B58D4 /* ToastWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 677A0873254BD47D000B58D4 /* ToastWindow.swift */; };
 		67E8B515233B97FD00D7CE80 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 67E8B517233B97FD00D7CE80 /* InfoPlist.strings */; };
 		67E8B521233C537B00D7CE80 /* fire.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 67E8B51E233C537B00D7CE80 /* fire.pdf */; };
 /* End PBXBuildFile section */
@@ -94,6 +95,7 @@
 		673C416825468A4800F462A3 /* FireMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireMenu.swift; sourceTree = "<group>"; };
 		673C417125468FFA00F462A3 /* ModifierKeyUpChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifierKeyUpChecker.swift; sourceTree = "<group>"; };
 		673C4177254697E400F462A3 /* TipsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipsWindow.swift; sourceTree = "<group>"; };
+		677A0873254BD47D000B58D4 /* ToastWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastWindow.swift; sourceTree = "<group>"; };
 		67E8B511233B978E00D7CE80 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		67E8B516233B97FD00D7CE80 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		67E8B518233B994000D7CE80 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 			children = (
 				673C417125468FFA00F462A3 /* ModifierKeyUpChecker.swift */,
 				673C4177254697E400F462A3 /* TipsWindow.swift */,
+				677A0873254BD47D000B58D4 /* ToastWindow.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -412,6 +415,7 @@
 				45577EB4254576720064325B /* FirePreferencesController.swift in Sources */,
 				459DE990232EB26600A3ACD1 /* CandidatesView.swift in Sources */,
 				673C4178254697E400F462A3 /* TipsWindow.swift in Sources */,
+				677A0874254BD47D000B58D4 /* ToastWindow.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Fire/CandidatesWindow.swift
+++ b/Fire/CandidatesWindow.swift
@@ -11,8 +11,14 @@ import InputMethodKit
 
 var set = false
 
-class CandidatesWindow: NSWindow {
+class CandidatesWindow: NSWindow, NSWindowDelegate {
     let hostingView = NSHostingView(rootView: CandidatesView(candidates: [], origin: ""))
+
+    func windowDidResize(_ notification: Notification) {
+        // 窗口大小变化时，确保不会超出当前屏幕范围
+        let origin = self.transformTopLeft(originalTopLeft: NSPoint(x: self.frame.minX, y: self.frame.maxY))
+        self.setFrameTopLeftPoint(origin)
+    }
 
     func setCandidates(
         candidates: [Candidate],
@@ -21,8 +27,7 @@ class CandidatesWindow: NSWindow {
     ) {
         hostingView.rootView.candidates = candidates
         hostingView.rootView.origin = originalString
-        let origin = self.transformTopLeft(originalTopLeft: topLeft)
-        self.setFrameTopLeftPoint(origin)
+        self.setFrameTopLeftPoint(topLeft)
         self.orderFront(nil)
     }
 
@@ -38,6 +43,7 @@ class CandidatesWindow: NSWindow {
         styleMask = .init(arrayLiteral: .fullSizeContentView, .borderless)
         isReleasedWhenClosed = false
         backgroundColor = NSColor.clear
+        delegate = self
         setSizePolicy()
     }
 

--- a/Fire/Fire.swift
+++ b/Fire/Fire.swift
@@ -34,7 +34,6 @@ class Fire: NSObject {
 
     override init() {
         super.init()
-        self.prepareStatement()
 
         preferencesObserver = Defaults.observe(keys: .codeMode, .candidateCount) { () in
             self.prepareStatement()

--- a/Fire/FireInputController.swift
+++ b/Fire/FireInputController.swift
@@ -72,7 +72,7 @@ class FireInputController: IMKInputController {
             let text = inputMode == .zhhans ? "中" : "英"
 
             // 在输入坐标处，显示中英切换提示
-            Utils.shared.tipsWindow.showTips(text, origin: getOriginPoint())
+            Utils.shared.toast?.show(text, position: getOriginPoint())
             return true
         }
         // 监听.flagsChanged事件只为切换中英文，其它情况不处理
@@ -280,13 +280,8 @@ class FireInputController: IMKInputController {
         curPage = 1
         candidatesWindow.close()
     }
-
-//    override func activateServer(_ sender: Any!) {
-//        NSLog("[FireInputController] active server: \(client()!.bundleIdentifier()!)")
-//    }
-
     override func deactivateServer(_ sender: Any!) {
-        NSLog("[FireInputController] deactivate server: \(client()!.bundleIdentifier()!)")
+        NSLog("[FireInputController] deactivate server: \(client().bundleIdentifier() ?? "no client deactivate")")
         clean()
     }
 }

--- a/Fire/FireInputController.swift
+++ b/Fire/FireInputController.swift
@@ -266,9 +266,11 @@ class FireInputController: IMKInputController {
 
     // 获取当前输入的光标位置
     private func getOriginPoint() -> NSPoint {
+        let xd: CGFloat = 0
+        let yd: CGFloat = 4
         var rect = NSRect()
         client().attributes(forCharacterIndex: 0, lineHeightRectangle: &rect)
-        return rect.origin
+        return NSPoint(x: rect.minX + xd, y: rect.minY - yd)
     }
 
     func clean() {

--- a/Fire/Preferences/GeneralPane.swift
+++ b/Fire/Preferences/GeneralPane.swift
@@ -18,47 +18,74 @@ struct GeneralPane: View {
     @Default(.wubiCodeTip) private var wubiCodeTip
     @Default(.showCodeInWindow) private var showCodeInWindow
     @Default(.candidatesDirection) var candidatesDirection
+    @Default(.inputModeTipWindowType) var inputModeTipWindowType
 
     var body: some View {
         Preferences.Container(contentWidth: 450.0) {
             Preferences.Section(title: "") {
                 VStack(alignment: .leading, spacing: 18) {
-                    HStack {
-                        Picker("编码方案", selection: $code) {
-                            Text("五笔").tag(CodeMode.wubi)
-                            Text("拼音").tag(CodeMode.pinyin)
-                            Text("五笔拼音混合").tag(CodeMode.wubiPinyin)
-                        }
-                        .frame(width: 180)
-                        Spacer(minLength: 50)
-                    }
-                    HStack {
-                        Toggle("满4码唯一候选词直接上屏", isOn: $wubiAutoCommit)
-                        Spacer(minLength: 50)
-                        Toggle("提示五笔编码", isOn: $wubiCodeTip)
-                        Spacer(minLength: 50)
-                    }
-                    Text("候选框")
-                    HStack {
-                        Picker("候选词排列", selection: $candidatesDirection) {
-                            Text("横向").tag(CandidatesDirection.horizontal)
-                            Text("竖向").tag(CandidatesDirection.vertical)
-                        }
-                        Spacer(minLength: 50)
-                        Picker("候选词数量", selection: $candidateCount) {
-                            Text("3").tag(3)
-                            Text("4").tag(4)
-                            Text("5").tag(5)
-                            Text("6").tag(6)
-                            Text("7").tag(7)
-                            Text("8").tag(8)
-                            Text("9").tag(9)
+                    GroupBox(label: Text("编码")) {
+                        VStack(spacing: 12) {
+                            HStack {
+                                Picker("编码方案", selection: $code) {
+                                    Text("五笔").tag(CodeMode.wubi)
+                                    Text("拼音").tag(CodeMode.pinyin)
+                                    Text("五笔拼音混合").tag(CodeMode.wubiPinyin)
+                                }
+                                .frame(width: 180)
+                                Spacer(minLength: 50)
+                            }
+                            HStack {
+                                Toggle("满4码唯一候选词直接上屏", isOn: $wubiAutoCommit)
+                                Spacer(minLength: 50)
+                                Toggle("提示五笔编码", isOn: $wubiCodeTip)
+                                Spacer(minLength: 50)
+                            }
                         }
                     }
-                    HStack {
-                        Toggle("候选框显示输入码", isOn: $showCodeInWindow)
+                    GroupBox(label: Text("候选词")) {
+                        VStack(spacing: 12) {
+                            HStack {
+                                Picker("候选词排列", selection: $candidatesDirection) {
+                                    Text("横向").tag(CandidatesDirection.horizontal)
+                                    Text("竖向").tag(CandidatesDirection.vertical)
+                                }
+                                Spacer(minLength: 50)
+                                Picker("候选词数量", selection: $candidateCount) {
+                                    Text("3").tag(3)
+                                    Text("4").tag(4)
+                                    Text("5").tag(5)
+                                    Text("6").tag(6)
+                                    Text("7").tag(7)
+                                    Text("8").tag(8)
+                                    Text("9").tag(9)
+                                }
+                            }
+                            HStack {
+                                Toggle("候选框显示输入码", isOn: $showCodeInWindow)
+                                Spacer(minLength: 20)
+                            }
+                        }
                     }
-                    Spacer(minLength: 20)
+                    GroupBox(label: Text("中英文切换")) {
+                        VStack(alignment: .leading, spacing: 12) {
+                            HStack {
+                                Picker(
+                                    "提示框位置",
+                                    selection: $inputModeTipWindowType
+                                ) {
+                                    Text("屏幕中间")
+                                    .tag(InputModeTipWindowType.centerScreen)
+                                    Text("跟随输入框")
+                                    .tag(InputModeTipWindowType.followInput)
+                                    Text("不显示")
+                                    .tag(InputModeTipWindowType.none)
+                                }
+                                .frame(width: 180)
+                                Spacer(minLength: 180)
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/Fire/Utils.swift
+++ b/Fire/Utils.swift
@@ -9,6 +9,7 @@
 import Cocoa
 import SwiftUI
 import InputMethodKit
+import Defaults
 
 enum HandlerStatus {
     case next
@@ -16,11 +17,26 @@ enum HandlerStatus {
 }
 
 class Utils {
-    let shiftKeyUpChecker = ModifierKeyUpChecker(.shift)
+    let shiftKeyUpChecker = ModifierKeyUpChecker(.shift, keyCode: kVK_Shift)
 
-    let tipsWindow = TipsWindow()
+    var toast: ToastWindowProtocol?
 
+    private func initToastWindow() {
+        toast = Defaults[.inputModeTipWindowType] == .centerScreen
+            ? ToastWindow()
+           : Defaults[.inputModeTipWindowType] == .followInput
+               ? TipsWindow()
+               : nil
+    }
+    private var toastSettingObserver: Defaults.Observation!
     init() {
+        toastSettingObserver = Defaults.observe(keys: .inputModeTipWindowType, .candidateCount) { () in
+            self.initToastWindow()
+        }
+    }
+
+    deinit {
+        toastSettingObserver.invalidate()
     }
 
     func processHandlers<T>(

--- a/Fire/Utils/ModifierKeyUpChecker.swift
+++ b/Fire/Utils/ModifierKeyUpChecker.swift
@@ -10,24 +10,40 @@ import Foundation
 import Carbon
 import Cocoa
 
-class ModifierKeyUpChecker {
-    init(_ modifier: NSEvent.ModifierFlags) {
-        checkModifier = modifier
-        lastModifier = .init(rawValue: 0)
+extension Date {
+    static func - (lhs: Date, rhs: Date) -> TimeInterval {
+        return lhs.timeIntervalSinceReferenceDate - rhs.timeIntervalSinceReferenceDate
     }
-    private let checkModifier: NSEvent.ModifierFlags
 
-    private var lastModifier: NSEvent.ModifierFlags
+}
 
-    // 检查shift键被抬起
+class ModifierKeyUpChecker {
+    init(_ modifier: NSEvent.ModifierFlags, keyCode: Int) {
+        checkModifier = modifier
+        checkKeyCode = keyCode
+    }
+    let checkModifier: NSEvent.ModifierFlags
+    let checkKeyCode: Int
+
+    private let delayInterval = 0.3
+
+    private var lastTime: Date = Date()
+
+    // 检查修饰键被按下并抬起
     func check(_ event: NSEvent) -> Bool {
         if event.type == .flagsChanged
             && event.modifierFlags == .init(rawValue: 0)
-            && lastModifier == checkModifier {  // shift键抬起
-            lastModifier = event.modifierFlags
+            && Date() - lastTime <= delayInterval {
+            // modifier keyup event
+            lastTime = Date(timeInterval: -3600*4, since: Date())
             return true
         }
-        lastModifier = event.type == .flagsChanged ? event.modifierFlags : .init(rawValue: 0)
+        if event.type == .flagsChanged && event.modifierFlags == checkModifier && event.keyCode == checkKeyCode {
+            // modifier keydown event
+            lastTime = Date()
+        } else {
+            lastTime = Date(timeInterval: -3600*4, since: Date())
+        }
         return false
     }
 }

--- a/Fire/Utils/TipsWindow.swift
+++ b/Fire/Utils/TipsWindow.swift
@@ -10,7 +10,7 @@ import Foundation
 import Cocoa
 import SwiftUI
 
-class TipsWindow {
+class TipsWindow: ToastWindowProtocol {
     private func createTipsWindow() {
         let window = NSWindow()
         window.styleMask = .init(arrayLiteral: .borderless, .fullSizeContentView)
@@ -43,12 +43,12 @@ class TipsWindow {
         tipsWindow?.orderFront(nil)
     }
 
-    func showTips(_ text: String, origin: NSPoint) {
-        NSLog("[utils] showTips: \(origin)")
+    func show(_ text: String, position: NSPoint) {
+        NSLog("[utils] showTips: \(position)")
         self.clearTimer()
         self.createTipsWindow()
         self.updateText(text: text)
-        self.showWindow(origin)
+        self.showWindow(position)
         self.resetTimer()
     }
     private func resetTimer() {

--- a/Fire/Utils/ToastWindow.swift
+++ b/Fire/Utils/ToastWindow.swift
@@ -1,0 +1,80 @@
+//
+//  ToastWindow.swift
+//  Fire
+//
+//  Created by marchyang on 2020/10/30.
+//  Copyright © 2020 qwertyyb. All rights reserved.
+//
+
+import Cocoa
+import SwiftUI
+
+class ToastWindow: NSWindow, ToastWindowProtocol {
+    struct ToastView: View {
+        var text: String
+        var body: some View {
+            VStack {
+                Text(text)
+                    .font(.system(size: 50))
+                    .fontWeight(.bold)
+                    .foregroundColor(.white)
+            }
+            .frame(width: 120, height: 120)
+            .background(Color.black.opacity(0.5))
+            .clipped()
+            .cornerRadius(20)
+        }
+    }
+
+    struct ToastView_Previews: PreviewProvider {
+        static var previews: some View {
+            ToastView(text: "中")
+        }
+    }
+
+    private var timer: Timer?
+
+    private let hostingView = NSHostingView(rootView: ToastView(text: ""))
+    override var acceptsFirstResponder: Bool {
+       return false
+    }
+
+    private func initWindow() {
+        isOpaque = false
+        backgroundColor = NSColor.clear
+        styleMask = .init(arrayLiteral: .borderless, .fullSizeContentView)
+        hasShadow = false
+        ignoresMouseEvents = true
+        isReleasedWhenClosed = false
+        level = NSWindow.Level(rawValue: NSWindow.Level.RawValue(CGShieldingWindowLevel()))
+    }
+    override init(
+        contentRect: NSRect,
+        styleMask style: NSWindow.StyleMask,
+        backing backingStoreType: NSWindow.BackingStoreType,
+        defer flag: Bool
+    ) {
+        super.init(contentRect: contentRect, styleMask: style, backing: backingStoreType, defer: flag)
+        initWindow()
+        contentView = hostingView
+    }
+
+    private func positionWindow() {
+        guard let screen = Utils.shared.getScreenFromPoint(NSEvent.mouseLocation) else {
+            return
+        }
+        let cx = (screen.frame.minX + screen.frame.maxX) / 2 - frame.width / 2
+        let cy = (screen.frame.maxY - screen.frame.minY) / 5 + screen.frame.minY
+        self.setFrameOrigin(NSPoint(x: cx, y: cy))
+    }
+
+    func show(_ text: String, position: NSPoint) {
+        timer?.invalidate()
+        hostingView.rootView.text = text
+        positionWindow()
+        orderFront(nil)
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: false, block: { (_) in
+            self.close()
+        })
+    }
+}

--- a/Fire/types.swift
+++ b/Fire/types.swift
@@ -15,10 +15,20 @@ enum CandidatesDirection: Int, Decodable, Encodable {
     case horizontal
 }
 
+enum InputModeTipWindowType: Int, Decodable, Encodable {
+    case followInput
+    case centerScreen
+    case none
+}
+
 extension Defaults.Keys {
     static let candidatesDirection = Key<CandidatesDirection>(
         "candidatesDirection",
         default: CandidatesDirection.horizontal
+    )
+    static let inputModeTipWindowType = Key<InputModeTipWindowType>(
+        "inputModeTipWindowType",
+        default: InputModeTipWindowType.centerScreen
     )
     static let showCodeInWindow = Key<Bool>("showCodeInWindow", default: true)
     static let wubiCodeTip = Key<Bool>("wubiCodeTip", default: true)
@@ -80,3 +90,7 @@ let punctution: [String: String] = [
     ">": "》",
     "?": "？"
 ]
+
+protocol ToastWindowProtocol {
+    func show(_ text: String, position: NSPoint)
+}


### PR DESCRIPTION
原方式设置数据后立刻通过window.frame去拿窗口的大小和位置信息是不正确的，由于此时窗口还没有更新，所以拿到的数据其实是上次布局后的矩形信息。
此次使用NSWindowDelegate的windowDidResize方法，在窗口大小发生变化时，立刻去检测更新窗口的位置，可以保证窗口按预期方式工作

Co-authored-by: marchyang <marchyang@tencent.com>