### PR TITLE
fix: 让剪贴簿热键等其他常用热键在输入法自身的视窗内生效

### DIFF
--- a/Fire/MainMenu.xib
+++ b/Fire/MainMenu.xib
@@ -30,6 +30,50 @@
                         </items>
                     </menu>
                 </menuItem>
+                <menuItem title="Edit" id="Uqo-ra-7f6">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <menu key="submenu" title="Edit" id="6QG-aB-bA4">
+                        <items>
+                            <menuItem title="Undo" keyEquivalent="z" id="gih-j8-8Yc">
+                                <connections>
+                                    <action selector="undo:" target="-1" id="wq2-WD-zon"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Redo" keyEquivalent="Z" id="Puv-75-KR0">
+                                <connections>
+                                    <action selector="redo:" target="-1" id="sCv-x3-xeJ"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="K1S-um-DmF"/>
+                            <menuItem title="Cut" keyEquivalent="x" id="cR6-a3-ng7">
+                                <connections>
+                                    <action selector="cut:" target="-1" id="Afb-ND-hgh"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Copy" keyEquivalent="c" id="Qhq-GT-srr">
+                                <connections>
+                                    <action selector="copy:" target="-1" id="FF8-xZ-OeX"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Paste" keyEquivalent="v" id="pKT-RU-UC0">
+                                <connections>
+                                    <action selector="paste:" target="-1" id="hba-9G-ECO"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Delete" id="cZh-KO-ZIT">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="delete:" target="-1" id="cI1-13-lgE"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Select All" keyEquivalent="a" id="TRk-bU-1eY">
+                                <connections>
+                                    <action selector="selectAll:" target="-1" id="Ped-i7-QhQ"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
             </items>
             <point key="canvasLocation" x="139" y="154"/>
         </menu>


### PR DESCRIPTION
上一个PR只修了视窗关闭与最小化的热键。
这次将任何可能涉及到剪贴簿编辑体验的热键都修了。

一个输入法应该不会用到诸如列印等功能吧……用到了再说。
拼写检查的热键也没有迁移过来。

关联 issue #47