### PR TITLE
chore: 全专案以 `import AppKit` 取代 `import Cocoa`。

### DIFF
--- a/Fire/AppDelegate.swift
+++ b/Fire/AppDelegate.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 qwertyyb. All rights reserved.
 //
 
-import Cocoa
+import AppKit
 import InputMethodKit
 
 @NSApplicationMain

--- a/Fire/Fire.swift
+++ b/Fire/Fire.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2019 qwertyyb. All rights reserved.
 //
 
-import Cocoa
+import AppKit
+import Defaults
 import InputMethodKit
 import Sparkle
-import Defaults
 
 let kConnectionName = "Fire_1_Connection"
 

--- a/Fire/Table/build.swift
+++ b/Fire/Table/build.swift
@@ -6,8 +6,7 @@
 //  Copyright © 2020 qwertyyb. All rights reserved.
 //
 
-import Foundation
-import Cocoa
+import AppKit
 import Defaults
 
 func getDatabaseURL () -> URL {

--- a/Fire/Utils.swift
+++ b/Fire/Utils.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2020 qwertyyb. All rights reserved.
 //
 
-import Cocoa
-import SwiftUI
-import InputMethodKit
+import AppKit
 import Defaults
+import InputMethodKit
+import SwiftUI
 
 enum HandlerStatus {
     case next

--- a/Fire/Utils/ModifierKeyUpChecker.swift
+++ b/Fire/Utils/ModifierKeyUpChecker.swift
@@ -6,9 +6,8 @@
 //  Copyright © 2020 qwertyyb. All rights reserved.
 //
 
-import Foundation
+import AppKit
 import Carbon
-import Cocoa
 
 extension Date {
     static func - (lhs: Date, rhs: Date) -> TimeInterval {

--- a/Fire/Utils/TipsWindow.swift
+++ b/Fire/Utils/TipsWindow.swift
@@ -6,8 +6,7 @@
 //  Copyright © 2020 qwertyyb. All rights reserved.
 //
 
-import Foundation
-import Cocoa
+import AppKit
 import SwiftUI
 
 class TipsWindow: ToastWindowProtocol {

--- a/Fire/Utils/ToastWindow.swift
+++ b/Fire/Utils/ToastWindow.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 qwertyyb. All rights reserved.
 //
 
-import Cocoa
+import AppKit
 import SwiftUI
 
 class ToastWindow: NSWindow, ToastWindowProtocol {


### PR DESCRIPTION
P.S.: 有 `import AppKit` 的话，`import Foundation` 理论上是不再需要专门加入的。