### PR TITLE
fix: 修复用户词库不生效的问题

### DIFF
--- a/Fire/DictManager.swift
+++ b/Fire/DictManager.swift
@@ -52,8 +52,8 @@ class DictManager {
                 type, min(query) as query
             from wb_py_dict
             where query glob :queryLike \(
-                codeMode == .wubi ? "and type = 'wb'"
-                                : codeMode == .pinyin ? "and type = 'py'" : "")
+                codeMode == .wubi ? "and type in ('wb', 'user')"
+                                : codeMode == .pinyin ? "and type in ('py', 'user')" : "")
             group by text
             order by query, id
             limit :offset, \(candidateCount + 1)
@@ -246,8 +246,10 @@ class DictManager {
         sqlite3_exec(database, "delete from wb_py_dict where type = '\(CandidateType.user.rawValue)'", nil, nil, nil)
         // 2. 添加用户词库
         let lines = dictContent.split(whereSeparator: \.isNewline)
+        NSLog("[DictManager] updateUserDict: \(lines)");
         let candidates = lines.map { (line) -> [Candidate] in
             let strs = line.split(whereSeparator: \.isWhitespace)
+            NSLog("[DictManager] line: \(line), strs: \(strs)")
             if strs.count <= 1 {
                 return []
             }
@@ -302,7 +304,7 @@ class DictManager {
             }
         }
         let content = list.map { dictItem in
-            ([dictItem.code] + dictItem.texts).joined(separator: "\t")
+            ([dictItem.code] + dictItem.texts).joined(separator: " ")
         }
         .joined(separator: "\n")
         return content

--- a/Fire/Preferences/UserDictPane.swift
+++ b/Fire/Preferences/UserDictPane.swift
@@ -37,17 +37,17 @@ struct UserDictPane: View {
                 Text("用户词库")
                 if #available(macOS 11.0, *) {
                     TextEditor(text: $userDictTextModel.text)
-                        .font(Font.system(size: 14))
+                        .font(Font.custom("Monaco", size: 14))
                         .frame(height: 400)
                         .lineSpacing(6)
                     Text("1. 编码需在行首")
-                        .font(Font.system(size: 11))
+                        .font(Font.system(size: 12))
                     Text("2. 编码和候选项之间需用空格分隔")
-                        .font(Font.system(size: 11))
+                        .font(Font.system(size: 12))
                     Text("3. 可以有多个候选项，每个候选项使用空格分隔")
-                        .font(Font.system(size: 11))
+                        .font(Font.system(size: 12))
                     Text("4. 候选项可使用{yyyy}/{MM}/{dd}/{HH}/{mm}/{ss}代替当前年/月/日/时/分/秒")
-                        .font(Font.system(size: 11))
+                        .font(Font.system(size: 12))
                     HStack {
                         Spacer()
                         if #available(macOS 12.0, *) {


### PR DESCRIPTION
1.修复在纯五笔或纯拼音编码模式下，用户词库不生效的问题
2. 修复保存后用户词库后，设置页面的空格变为制表符的问题

close #143