### PR TITLE
feat: 移除繁体中文输出功能

### DIFF
--- a/Fire/Fire.swift
+++ b/Fire/Fire.swift
@@ -7,7 +7,6 @@
 //
 
 import AppKit
-import Defaults
 import InputMethodKit
 import Sparkle
 
@@ -90,27 +89,7 @@ class Fire: NSObject {
             let candidate = Candidate(code: "z", text: text, type: .user)
             return ([candidate], false)
         }
-        let (candidates, hasNext) = DictManager.shared.getCandidates(query: origin, page: page)
-        // 简体输出跳过转换；繁体输出使用 CFStringTransform 简→繁
-        let chineseOutputMode = Defaults[.chineseOutputMode]
-        var transformed = candidates.map { (candidate) -> Candidate in
-            let text: String
-            if chineseOutputMode == .traditional {
-                let mutableStr = NSMutableString(string: candidate.text)
-                CFStringTransform(mutableStr, nil, "Hans-Hant" as CFString, false)
-                text = mutableStr as String
-            } else {
-                text = candidate.text
-            }
-            // 同时传递拆字(spelling)和拼音(pinyin)数据，供候选提示模式使用
-            return Candidate(code: candidate.code, text: text, type: candidate.type,
-                              spelling: candidate.spelling, pinyin: candidate.pinyin)
-        }
-        // 简繁转换后可能出现"同一个词但不同编码"导致的重复（如简繁同形字），
-        // 用 Set 去重并保留首次出现的候选（即原排序靠前的）
-        var seen = Set<String>()
-        transformed = transformed.filter { seen.insert($0.text).inserted }
-        return (transformed, hasNext)
+        return DictManager.shared.getCandidates(query: origin, page: page)
     }
 
     static let shared = Fire()

--- a/Fire/Preferences/GeneralPane.swift
+++ b/Fire/Preferences/GeneralPane.swift
@@ -33,7 +33,6 @@ struct GeneralPane: View {
     @Default(.showInputModeStatus) private var showInputModeStatus
     @Default(.enableWhitespaceBetweenZhEn) private var enableWhitespaceBetweenZhEn
     @Default(.spellingScheme) private var spellingScheme
-    @Default(.chineseOutputMode) private var chineseOutputMode
     @Default(.enableExactMatch) private var enableExactMatch
     @Default(.celebrationEffect) private var celebrationEffect
     @Default(.hotkeyModifier) private var hotkeyModifier
@@ -97,10 +96,6 @@ struct GeneralPane: View {
                 }
                 PreferenceToggleRow(title: "显示输入码", caption: "不内嵌文本框", isOn: $showCodeInWindow)
                 PreferenceToggleRow(title: "显示生僻字", isOn: $enableGBK)
-                PreferenceToggleRow(title: "输出繁体", isOn: Binding(
-                    get: { chineseOutputMode == .traditional },
-                    set: { chineseOutputMode = $0 ? .traditional : .simplified }
-                ))
                 PreferencePickerRow(title: "二三候选词额外选择键") {
                     Picker("", selection: $extraCandidateSelectKeys) {
                         Text("禁用").tag(ExtraCandidateSelectKeys.disabled)

--- a/Fire/Types/DefaultsKeys.swift
+++ b/Fire/Types/DefaultsKeys.swift
@@ -66,7 +66,6 @@ extension Defaults.Keys {
     static let pyTablePath = Key<String>("pyTableURL", default: Bundle.main.resourceURL?.appendingPathComponent("py_table.txt").path ?? "")
     static let spellingScheme = Key<SpellingScheme>("spellingScheme", default: .wubi86)
     static let enableGBK = Key<Bool>("enableGBK", default: true)
-    static let chineseOutputMode = Key<ChineseOutputMode>("chineseOutputMode", default: .simplified)
     static let enableExactMatch = Key<Bool>("enableExactMatch", default: false)
     static let enableStatistics = Key<Bool>("enableStatistics", default: true)
     static let celebrationEffect = Key<CelebrationEffectType>("celebrationEffect", default: .none)

--- a/Fire/types.swift
+++ b/Fire/types.swift
@@ -38,12 +38,6 @@ enum CandidateHintMode: String, Codable, Defaults.Serializable {
     case pinyin     // 显示拼音
 }
 
-// 中文输出模式：控制候选词以简体还是繁体输出
-enum ChineseOutputMode: String, Codable, Defaults.Serializable {
-    case simplified     // 简体中文
-    case traditional    // 繁体中文
-}
-
 enum InputModeTipWindowType: Int, Decodable, Encodable, Defaults.Serializable {
     case followInput
     case centerScreen


### PR DESCRIPTION
- 移除 `ChineseOutputMode` 枚举类型定义
- 移除 `Defaults.Keys.chineseOutputMode` 默认值键
- 移除候选项简繁转换逻辑（CFStringTransform）
- 移除偏好设置中的"输出繁体"开关界面
- 候选词生成直接返回 `DictManager` 原始结果，不再进行繁简转换与去重

Related to #176