### PR TITLE
fix: 将 control 键图标从 chevron.up 替换为正确的 control SF Symbol

### DIFF
--- a/Fire/FireInputController.swift
+++ b/Fire/FireInputController.swift
@@ -126,10 +126,7 @@ class FireInputController: IMKInputController {
             return nil
         }
 
-        let hotkeyMod = Defaults[.hotkeyModifier]
-        let hotkeyFlag = hotkeyMod.nsModifierFlag
-
-        // {hotkey}+Shift+数字：从词库删除对应候选词
+        // Ctrl+Shift+数字：从词库删除对应候选词
         // 按住 Shift 时数字键的 charactersIgnoringModifiers 会变成符号(如 Shift+1 -> !)，
         // 无法用 Int 解析，这里改用 keyCode 映射数字
         let digitByKeyCode: [UInt16: Int] = [
@@ -138,13 +135,13 @@ class FireInputController: IMKInputController {
             UInt16(kVK_ANSI_7): 7, UInt16(kVK_ANSI_8): 8, UInt16(kVK_ANSI_9): 9
         ]
         let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        let deleteModifiers: NSEvent.ModifierFlags = [hotkeyFlag, .shift]
+        let deleteModifiers: NSEvent.ModifierFlags = [.control, .shift]
         if modifiers == deleteModifiers,
            let deleteIndex = digitByKeyCode[event.keyCode],
            deleteIndex <= _candidates.count {
             let target = _candidates[deleteIndex - 1]
             if target.type != .placeholder {
-                NSLog("hotkey: \(hotkeyMod.rawValue) + shift + \(deleteIndex), delete confirm: \(target.text)")
+                NSLog("hotkey: control + shift + \(deleteIndex), delete confirm: \(target.text)")
                 if _pendingDeleteCandidate == target {
                     // 再按一次同一组合键 = 确认删除
                     confirmDelete(target)
@@ -156,23 +153,24 @@ class FireInputController: IMKInputController {
             }
             return true
         }
-        // {hotkey}+= ：在无正在输入原码时进入"快速加词"组词模式
-        if modifiers == hotkeyFlag, event.keyCode == UInt16(kVK_ANSI_Equal), _originalString.isEmpty {
+        // Ctrl+= ：在无正在输入原码时进入"快速加词"组词模式
+        if modifiers == .control, event.keyCode == UInt16(kVK_ANSI_Equal), _originalString.isEmpty {
             if Fire.shared.recentCommittedTexts.count >= 2 {
                 _combineCount = 2
                 markCombineText()
                 showCombinePreview()
             } else {
-                Utils.shared.showMessage("请先输入至少两个字，再按 \(hotkeyMod.rawValue)+= 组词")
+                Utils.shared.showMessage("请先输入至少两个字，再按 control+= 组词")
             }
             return true
         }
         guard let chars = event.charactersIgnoringModifiers, let num = Int(chars) else {
             return nil
         }
-        if modifiers == hotkeyFlag &&
+        // Ctrl+Option+数字：置顶候选词
+        if modifiers == [.control, .option] &&
             num > 0 && num <= _candidates.count {
-            NSLog("hotkey: \(hotkeyMod.rawValue) + \(num)")
+            NSLog("hotkey: control + option + \(num)")
             DictManager.shared.setCandidateToFirst(query: _originalString, candidate: _candidates[num-1])
             self.curPage = 1
             self.refreshCandidatesWindow()

--- a/Fire/Preferences/GeneralPane.swift
+++ b/Fire/Preferences/GeneralPane.swift
@@ -129,10 +129,7 @@ struct GeneralPane: View {
                     .disabled(disableEnMode)
                 PreferencePickerRow(title: "中英文切换快捷键") {
                     Picker("", selection: $toggleInputModeKey) {
-                        HStack {
-                            Image(systemName: "chevron.up")
-                            Text("control")
-                        }.tag(ModifierKey.control)
+                        Label("control", systemImage: "control").tag(ModifierKey.control)
                         Label("shift", systemImage: "shift").tag(ModifierKey.shift)
                         Label("左shift", systemImage: "shift").tag(ModifierKey.leftShift)
                         Label("右shift", systemImage: "shift").tag(ModifierKey.rightShift)
@@ -160,9 +157,10 @@ struct GeneralPane: View {
             Section {
                 PreferencePickerRow(title: "热键修饰键") {
                     Picker("", selection: $hotkeyModifier) {
-                        Text("Control").tag(HotkeyModifier.control)
-                        Text("Option").tag(HotkeyModifier.option)
-                        Text("Command").tag(HotkeyModifier.command)
+                        // 热键修饰键选项补充 sf symbol 图标
+                        Label("control", systemImage: "control").tag(HotkeyModifier.control)
+                        Label("option", systemImage: "option").tag(HotkeyModifier.option)
+                        Label("command", systemImage: "command").tag(HotkeyModifier.command)
                     }
                     .labelsHidden()
                 }
@@ -203,7 +201,7 @@ struct GeneralPane: View {
     }
     private var hotkeyIcon: String {
         switch hotkeyModifier {
-        case .control: return "chevron.up"
+        case .control: return "control"
         case .option: return "option"
         case .command: return "command"
         }

--- a/Fire/Preferences/GeneralPane.swift
+++ b/Fire/Preferences/GeneralPane.swift
@@ -35,7 +35,6 @@ struct GeneralPane: View {
     @Default(.spellingScheme) private var spellingScheme
     @Default(.enableExactMatch) private var enableExactMatch
     @Default(.celebrationEffect) private var celebrationEffect
-    @Default(.hotkeyModifier) private var hotkeyModifier
 
     var body: some View {
         Form {
@@ -154,57 +153,8 @@ struct GeneralPane: View {
             } header: {
                 Text("中英文切换")
             }
-            Section {
-                PreferencePickerRow(title: "热键修饰键") {
-                    Picker("", selection: $hotkeyModifier) {
-                        // 热键修饰键选项补充 sf symbol 图标
-                        Label("control", systemImage: "control").tag(HotkeyModifier.control)
-                        Label("option", systemImage: "option").tag(HotkeyModifier.option)
-                        Label("command", systemImage: "command").tag(HotkeyModifier.command)
-                    }
-                    .labelsHidden()
-                }
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(spacing: 6) {
-                        KeyCap(hotkeyModifier.rawValue, icon: hotkeyIcon)
-                        Text("+").font(.caption2).foregroundStyle(.tertiary)
-                        KeyCap("数字")
-                        Text("置顶候选词")
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                    }
-                    HStack(spacing: 6) {
-                        KeyCap(hotkeyModifier.rawValue, icon: hotkeyIcon)
-                        Text("+").font(.caption2).foregroundStyle(.tertiary)
-                        KeyCap("shift", icon: "shift")
-                        Text("+").font(.caption2).foregroundStyle(.tertiary)
-                        KeyCap("数字")
-                        Text("删除候选词")
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                    }
-                    HStack(spacing: 6) {
-                        KeyCap(hotkeyModifier.rawValue, icon: hotkeyIcon)
-                        Text("+").font(.caption2).foregroundStyle(.tertiary)
-                        KeyCap("=")
-                        Text("快速加词")
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                    }
-                }
-                .padding(.leading, 4)
-            } header: {
-                Text("热键")
-            }
         }
         .formStyle(.grouped)
-    }
-    private var hotkeyIcon: String {
-        switch hotkeyModifier {
-        case .control: return "control"
-        case .option: return "option"
-        case .command: return "command"
-        }
     }
 }
 

--- a/Fire/Preferences/KeyCap.swift
+++ b/Fire/Preferences/KeyCap.swift
@@ -43,7 +43,7 @@ struct KeyCap: View {
 
 #Preview {
     HStack(spacing: 6) {
-        KeyCap("control", icon: "chevron.up")
+        KeyCap("control", icon: "control")
         Text("+").font(.caption2).foregroundStyle(.tertiary)
         KeyCap("=")
         Text("说明文字").font(.caption2).foregroundStyle(.tertiary)

--- a/Fire/Preferences/UserDictPane.swift
+++ b/Fire/Preferences/UserDictPane.swift
@@ -24,7 +24,6 @@ struct UserDictRow: Identifiable, Equatable {
 // MARK: - 偏好设置面板
 
 struct UserDictPane: View {
-    @Default(.hotkeyModifier) private var hotkeyModifier
     @State private var rows: [UserDictRow] = []
     @State private var savedSnapshot: [UserDictRow] = []
     @State private var showAlert = false
@@ -39,7 +38,7 @@ struct UserDictPane: View {
                 // 快捷键说明
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 6) {
-                        KeyCap(hotkeyModifier.rawValue, icon: hotkeyIcon)
+                        KeyCap("control", icon: "control")
                         Text("+")
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
@@ -49,7 +48,11 @@ struct UserDictPane: View {
                             .foregroundStyle(.tertiary)
                     }
                     HStack(spacing: 6) {
-                        KeyCap(hotkeyModifier.rawValue, icon: hotkeyIcon)
+                        KeyCap("control", icon: "control")
+                        Text("+")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                        KeyCap("option", icon: "option")
                         Text("+")
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
@@ -206,7 +209,7 @@ struct UserDictPane: View {
                 HStack {
                     VStack(alignment: .leading, spacing: 6) {
                         HStack(spacing: 6) {
-                            KeyCap(hotkeyModifier.rawValue, icon: hotkeyIcon)
+                            KeyCap("control", icon: "control")
                             Text("+")
                                 .font(.caption2)
                                 .foregroundStyle(.tertiary)
@@ -270,14 +273,6 @@ struct UserDictPane: View {
         }
         .onChange(of: rows) { _ in
             isModified = (rows != savedSnapshot)
-        }
-    }
-
-    private var hotkeyIcon: String {
-        switch hotkeyModifier {
-        case .control: return "control"
-        case .option: return "option"
-        case .command: return "command"
         }
     }
 

--- a/Fire/Preferences/UserDictPane.swift
+++ b/Fire/Preferences/UserDictPane.swift
@@ -275,7 +275,7 @@ struct UserDictPane: View {
 
     private var hotkeyIcon: String {
         switch hotkeyModifier {
-        case .control: return "chevron.up"
+        case .control: return "control"
         case .option: return "option"
         case .command: return "command"
         }

--- a/Fire/Types/DefaultsKeys.swift
+++ b/Fire/Types/DefaultsKeys.swift
@@ -45,7 +45,6 @@ extension Defaults.Keys {
     static let disableEnMode = Key<Bool>("diableEnMode", default: false)
     static let disableTempEnMode = Key<Bool>("disableTempEnMode", default: false)
     static let toggleInputModeKey = Key<ModifierKey>("toggleInputModeKey", default: .shift)
-    static let hotkeyModifier = Key<HotkeyModifier>("hotkeyModifier", default: .control)
     static let inputModeTipWindowType = Key<InputModeTipWindowType>("inputModeTipWindowType", default: .centerScreen)
     static let showInputModeStatus = Key<Bool>("showInputModeStatus", default: true)
     static let themeConfig = Key<ThemeConfig>("themeConfig", default: defaultThemeConfig)

--- a/Fire/types.swift
+++ b/Fire/types.swift
@@ -61,28 +61,6 @@ enum ModifierKey: String, Codable, Defaults.Serializable {
   case function
 }
 
-/// 热键可用的修饰键（不包含 shift/fn/leftShift/rightShift，因为这些不适合作为主修饰键）
-enum HotkeyModifier: String, Codable, Defaults.Serializable, CaseIterable {
-    case control
-    case option
-    case command
-
-    var nsModifierFlag: NSEvent.ModifierFlags {
-        switch self {
-        case .control: return .control
-        case .option: return .option
-        case .command: return .command
-        }
-    }
-
-    var cgEventFlag: CGEventFlags {
-        switch self {
-        case .control: return .maskControl
-        case .option: return .maskAlternate
-        case .command: return .maskCommand
-        }
-    }
-}
 
 class ApplicationSettingItem: ObservableObject, Codable, Identifiable, Defaults.Serializable {
     var id: String { bundleIdentifier }


### PR DESCRIPTION
- GeneralPane: 中英文切换快捷键和热键修饰键的 control 选项改用 control 图标
- GeneralPane: hotkeyIcon 方法中 control 键改用 control 图标
- KeyCap: 预览示例中的图标更新为 control
- UserDictPane: hotkeyIcon 方法中 control 键改用 control 图标