### PR TITLE
fix: 优化候选词翻页时的高亮定位逻辑

### DIFF
--- a/Fire/FireInputController.swift
+++ b/Fire/FireInputController.swift
@@ -412,7 +412,10 @@ class FireInputController: IMKInputController {
                         selectedIndex -= 1
                         CandidatesWindow.shared.setSelectedIndex(selectedIndex)
                     } else if curPage > 1 {
-                        prevPage()
+                        curPage -= 1
+                        // 方向键到头回绕：高亮定位到上一页的最后一个候选词
+                        selectedIndex = _candidates.count - 1
+                        CandidatesWindow.shared.setSelectedIndex(selectedIndex)
                     }
                 }
                 return true


### PR DESCRIPTION
- 回退翻页时高亮定位到上一页的最后一个候选词（自然的回绕行为），而非始终定位到第一个
- 前进翻页时先重置高亮再翻页，确保窗口刷新时高亮已正确归零（聚焦在首个候选词）
