### PR TITLE
fix(FireInputController): 修正汉字后数字输入自动加空格，数字标记被覆盖的问题

### DIFF
--- a/Fire/FireInputController.swift
+++ b/Fire/FireInputController.swift
@@ -499,11 +499,11 @@ class FireInputController: IMKInputController {
                 }
                 return true
             }
-            _lastInputIsNumber = true
             if Defaults[.enableWhitespaceBetweenZhEn] && Utils.shared.shouldConcatWithWhitespace(_lastInputText, string) {
                 // 中文后输入了数字，先插入一个空格
                 insertText(" ")
             }
+            _lastInputIsNumber = true
         }
         return nil
     }


### PR DESCRIPTION
- 将 `_lastInputIsNumber = true` 移至插入空格之后，确保在插入空格后不会被 insertText 方法内的逻辑覆盖`_lastInputIsNumber = true` 
- 测试样本：ip 地址 0.0.0.0 测试，修复前：ip 地址 0。0.0.0 测试